### PR TITLE
Add missing slidedown events

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Use listeners to react to OneSignal-related events:
 | Event Name | Callback Argument Type |
 |-|-|
 |'slidedownShown'      | boolean |
+|'slidedownClosed'      | boolean |
+|'slidedownAllowClick'      | boolean |
+|'slidedownCancelClick'      | boolean |
 
 ### Push Subscription Namespace
 | Event Name | Callback Argument Type |

--- a/index.ts
+++ b/index.ts
@@ -128,7 +128,7 @@ interface IOneSignalTagCategory { tag: string; label: string; checked?: boolean;
 type PushSubscriptionNamespaceProperties = { id: string | null | undefined; token: string | null | undefined; optedIn: boolean; };
 type SubscriptionChangeEvent = { previous: PushSubscriptionNamespaceProperties; current: PushSubscriptionNamespaceProperties; };
 type NotificationEventName = 'click' | 'foregroundWillDisplay' | 'dismiss' | 'permissionChange' | 'permissionPromptDisplay';
-type SlidedownEventName = 'slidedownShown';
+type SlidedownEventName = 'slidedownShown' | 'slidedownClosed' | 'slidedownAllowClick' | 'slidedownCancelClick';
 type OneSignalDeferredLoadedCallback = (onesignal: IOneSignalOneSignal) => void;
 interface IOSNotification {
   /**


### PR DESCRIPTION
There's a missing information about slide down events that are useful. If you are looking for a proper event listener on how to detect if the user allowed / cancelled / closed the slide down prompt, you should utilize the following:
-  'slidedownAllowClick' 
-  'slidedownCancelClick'
- 'slidedownClosed'

Added this as part of the types for SlidedownEventName and updated the readme.

Verified this is working through a manual test. [see here](https://github.com/OneSignal/OneSignal-Website-SDK/blob/d2302b6026138db358ba786a7da6ecae159af01c/src/page/slidedown/Slidedown.ts#L331) If you want to check the missing event names from original OneSignal Web SDK