### PR TITLE
sync with web-shim-codegen v3.0.5

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,9 @@ build
 
 npm-debug.log*
 example
+
+.github
+.releaserc.json
+
+.eslintignore
+.gitignore

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - 🏠 [Homepage](https://onesignal.com)
 - 🖤 [npm](https://www.npmjs.com/package/onesignal-vue)
 
-OneSignal is the world's leader for Mobile Push Notifications, Web Push, and In-App Messaging. It is trusted by 800k businesses to send 5 billion Push Notifications per day.
+OneSignal is the world's leader for Mobile Push Notifications, Web Push, and In-App Messaging. It is trusted by 2 million+ developers to send 12 billion Push Notifications per day.
 
 You can find more information on OneSignal [here](https://onesignal.com/).
 
@@ -123,7 +123,7 @@ export default {
 
 ### Init Options
 
-You can pass other [options](https://documentation.onesignal.com/v11.0/docs/web-sdk#initializing-the-sdk) to the `init` function. Use these options to configure personalized prompt options, auto-resubscribe, and more.
+You can pass other [options](https://documentation.onesignal.com/docs/web-sdk-reference#init) to the `init` function. Use these options to configure personalized prompt options, auto-resubscribe, and more.
 
 <details>
   <summary>Expand to see more options</summary>
@@ -194,7 +194,7 @@ interface IOneSignalOneSignal {
 
 ### OneSignal API
 
-See the official [OneSignal WebSDK reference](https://documentation.onesignal.com/v11.0/docs/web-sdk#initializing-the-sdk) for information on all available SDK functions.
+See the official [OneSignal WebSDK reference](https://documentation.onesignal.com/docs/web-sdk) for information on all available SDK functions.
 
 ---
 
@@ -234,7 +234,7 @@ this.$OneSignal.Notifications.addEventListener('click', (event) => {
 });
 ```
 
-See the [OneSignal WebSDK Reference](https://documentation.onesignal.com/v11.0/docs/web-sdk#initializing-the-sdk) for all available event listeners.
+See the [OneSignal WebSDK Reference](https://documentation.onesignal.com/docs/web-sdk-reference#addeventlistener-push-notification) for all available event listeners.
 
 ---
 

--- a/index.ts
+++ b/index.ts
@@ -73,6 +73,11 @@ const init = (options: IInitObject): Promise<void> => {
     return Promise.reject(`Document is not defined.`);
   }
 
+  // Handle both disabled and disable keys for welcome notification
+  if (options.welcomeNotification?.disabled !== undefined) {
+    options.welcomeNotification.disable = options.welcomeNotification.disabled;
+  }
+
   return new Promise<void>((resolve, reject) => {
     window.OneSignalDeferred?.push((OneSignal) => {
       OneSignal.init(options)
@@ -341,8 +346,14 @@ export interface IInitObject {
   welcomeNotification?: {
     /**
      * Disables sending a welcome notification to new site visitors. If you want to disable welcome notifications, this is the only option you need.
+     * @deprecated Use 'disable' instead. This will be removed in a future version.
      */
     disabled?: boolean;
+
+    /**
+     * Disables sending a welcome notification to new site visitors. If you want to disable welcome notifications, this is the only option you need.
+     */
+    disable?: boolean;
 
     /**
      * The welcome notification's message. You can localize this to your own language.
@@ -360,7 +371,7 @@ export interface IInitObject {
      * By default, clicking the welcome notification does not open any link.
      * This is recommended because the user has just visited your site and subscribed.
      */
-    url: string;
+    url?: string;
   };
 
   /**
@@ -491,7 +502,7 @@ export interface IOneSignalSlidedown {
 	removeEventListener(event: SlidedownEventName, listener: (wasShown: boolean) => void): void;
 }
 export interface IOneSignalDebug {
-	setLogLevel(logLevel: string): void;
+	setLogLevel(logLevel: 'trace' | 'debug' | 'info' | 'warn' | 'error'): void;
 }
 export interface IOneSignalSession {
 	sendOutcome(outcomeName: string, outcomeWeight?: number): Promise<void>;
@@ -878,9 +889,10 @@ function userRemoveTags(keys: string[]): void {
   });
   
 }
-function userGetTags(): { [key: string]: string } {
+// @ts-expect-error - return non-Promise type despite needing to await OneSignalDeferred
+async function userGetTags(): { [key: string]: string } {
   let retVal: { [key: string]: string };
-  window.OneSignalDeferred?.push((OneSignal) => {
+  await window.OneSignalDeferred?.push((OneSignal) => {
     retVal = OneSignal.User.getTags();
   });
   return retVal;
@@ -906,9 +918,10 @@ function userSetLanguage(language: string): void {
   });
   
 }
-function userGetLanguage(): string {
+// @ts-expect-error - return non-Promise type despite needing to await OneSignalDeferred
+async function userGetLanguage(): string {
   let retVal: string;
-  window.OneSignalDeferred?.push((OneSignal) => {
+  await window.OneSignalDeferred?.push((OneSignal) => {
     retVal = OneSignal.User.getLanguage();
   });
   return retVal;
@@ -961,7 +974,7 @@ function pushSubscriptionRemoveEventListener(event: 'change', listener: (change:
   });
   
 }
-function debugSetLogLevel(logLevel: string): void {
+function debugSetLogLevel(logLevel: 'trace' | 'debug' | 'info' | 'warn' | 'error'): void {
   
   window.OneSignalDeferred?.push((OneSignal) => {
     OneSignal.Debug.setLogLevel(logLevel);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onesignal-vue",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onesignal-vue",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "vue": "^2.6.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onesignal-vue",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Vue OneSignal Plugin: Make it easy to integrate OneSignal with your Vue App!",
   "type": "module",
   "contributors": [
@@ -26,6 +26,13 @@
     "eslint": "^8.13.0",
     "typescript": "^4.6.3"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "MigrationGuide.md"
+  ],
   "keywords": [
     "onesignal",
     "push",


### PR DESCRIPTION
## Changes

- improve types for `setLogLevel` method
- pass `welcomeNotification.disabled` as `disable` to web SDK
- set `welcomeNotification.url` to be optional
- await `OneSignalDeferred` to complete processing for endpoints such as `getTags()` and `getLanguage()`
- improvements to distributed bundle size