### PR TITLE
feat: add `IDisplayableOSNotification` type 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -226,6 +226,10 @@ export interface IOSNotificationActionButton {
   readonly launchURL?: string;
 }
 
+export interface IDisplayableOSNotification extends IOSNotification {
+  display(): void;
+}
+
 export interface NotificationClickResult {
   readonly actionId?: string;
   readonly url?: string;
@@ -240,7 +244,7 @@ export type NotificationEventTypeMap = {
 };
 
 export interface NotificationForegroundWillDisplayEvent {
-  readonly notification: IOSNotification;
+  readonly notification: IDisplayableOSNotification;
   preventDefault(): void;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onesignal-vue",
-  "version": "2.5.4",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onesignal-vue",
-      "version": "2.5.4",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "vue": "^2.6.14"


### PR DESCRIPTION
## Features

- adds the `IDisplayableOSNotification` interface including:
  - `display()` - re-displays a notification previously suppressed by `preventDefault()`